### PR TITLE
DRYD-979: Update styling to resemble record editor title bar.

### DIFF
--- a/src/components/record/MiniView.jsx
+++ b/src/components/record/MiniView.jsx
@@ -23,7 +23,7 @@ const messages = defineMessages({
   authority: {
     id: 'recordTitleBar.authority',
     description: 'For authority items, the record type and vocabulary displayed next to the title.',
-    defaultMessage: '({recordType} - {vocabulary})',
+    defaultMessage: '{recordType} - {vocabulary}',
   },
 });
 

--- a/styles/cspace-ui/MiniView.css
+++ b/styles/cspace-ui/MiniView.css
@@ -7,6 +7,11 @@
   font-weight: 600;
   font-size: 14px;
   margin: 0;
+  display: flex;
+}
+
+.common > h3 > a {
+  flex: 1 1 auto;
 }
 
 .authority {
@@ -20,5 +25,16 @@
 }
 
 .secondaryTitle {
+  flex: 0 0 auto;
   margin-left: 4px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.authority .secondaryTitle {
+  color: #734592;
+}
+
+.procedure .secondaryTitle {
+  color: #305A8D;
 }


### PR DESCRIPTION
I'd like to make this look more like the title bar of the record editor:

![miniview](https://user-images.githubusercontent.com/1395885/151644135-1ba63e49-7594-4adf-bf8e-f6aa83c082b1.png)

(I'm just going to assume Megan will be ok with this.)